### PR TITLE
fixes: buffer overflow, errno handling, docs, tests, CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,11 +3,11 @@ stages:
 
 default:
   tags:
-    - docker-exec
+    - k8s
   before_script:
     - |
-        curl "https://api.github.com/repos/qorelanguage/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
-        -X POST -u omusil24:${GITHUB_ACCESS_TOKEN} -H "Content-Type: application/json" \
+        curl "https://api.github.com/repos/qoretechnologies/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
+        -X POST -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -H "Content-Type: application/json" \
         -d "{\"state\": \"pending\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
     - set +e
 
@@ -20,13 +20,13 @@ test-ubuntu:
   script:
     - |
         if test/docker_test/test-ubuntu.sh; then
-          curl "https://api.github.com/repos/qorelanguage/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
-            -X POST -u omusil24:${GITHUB_ACCESS_TOKEN} -H "Content-Type: application/json" \
+          curl "https://api.github.com/repos/qoretechnologies/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
+            -X POST -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -H "Content-Type: application/json" \
             -d "{\"state\": \"success\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 0
         else
-          curl "https://api.github.com/repos/qorelanguage/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
-            -X POST -u omusil24:${GITHUB_ACCESS_TOKEN} -H "Content-Type: application/json" \
+          curl "https://api.github.com/repos/qoretechnologies/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
+            -X POST -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -H "Content-Type: application/json" \
             -d "{\"state\": \"failure\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 1
         fi
@@ -37,13 +37,13 @@ test-alpine:
   script:
     - |
         if test/docker_test/test-alpine.sh; then
-          curl "https://api.github.com/repos/qorelanguage/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
-            -X POST -u omusil24:${GITHUB_ACCESS_TOKEN} -H "Content-Type: application/json" \
+          curl "https://api.github.com/repos/qoretechnologies/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
+            -X POST -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -H "Content-Type: application/json" \
             -d "{\"state\": \"success\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 0
         else
-          curl "https://api.github.com/repos/qorelanguage/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
-            -X POST -u omusil24:${GITHUB_ACCESS_TOKEN} -H "Content-Type: application/json" \
+          curl "https://api.github.com/repos/qoretechnologies/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
+            -X POST -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -H "Content-Type: application/json" \
             -d "{\"state\": \"failure\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 1
         fi

--- a/README
+++ b/README
@@ -1,20 +1,78 @@
+Qore sysconf Module
+===================
 
-* BUILD INSTRUCTIONS *
+The sysconf module provides Qore with access to runtime system configuration
+information from the underlying operating system. The functionality wraps
+standard C library system configuration functions.
+
+Functions provided:
+- sysconf(): Get system-wide runtime parameters (CPU count, memory limits, etc.)
+- confstr(): Get string-valued configuration parameters (paths, versions, etc.)
+- pathconf(): Query file system limits for specific paths
+
+Quick Start
+-----------
+
+    %requires sysconf
+
+    # Get the number of online CPUs
+    printf("CPUs online: %d\n", sysconf(Sysconf::SC_NPROCESSORS_ONLN));
+
+    # Get system page size
+    printf("Page size: %d bytes\n", sysconf(Sysconf::SC_PAGESIZE));
+
+    # Get maximum filename length for a path
+    printf("Max filename length: %d\n", pathconf("/tmp", Pathconf::PC_NAME_MAX));
+
+    # Get the default PATH
+    printf("Default PATH: %s\n", confstr(Confstr::CS_PATH));
+
+Build Instructions
+------------------
 
 Requirements:
- - Qore development environment (lib and headers)
- - Cmake
- - (optional) DOxygen
+ - Qore 1.12.4+ development environment (lib and headers)
+ - CMake 2.8.12+
+ - C++11 compatible compiler
+ - (optional) Doxygen for documentation
 
-Use so called "out of source" build
+Use "out of source" build:
 
- - mkdir build   (in module directory)
- - cd build
- - cmake -DCMAKE_INSTALL_PREFIX=/path/to/install ..   (if there is not -DCMAKE_INSTALL_PREFIX specified, the Qore module dire is used)
- - make
- - cross fingers
- - make install
+    mkdir build
+    cd build
+    cmake -DCMAKE_INSTALL_PREFIX=/path/to/install ..
+    make
+    make install
 
-Some tests are located in "test" directory.
+If -DCMAKE_INSTALL_PREFIX is not specified, the Qore module directory is used.
 
+Running Tests
+-------------
 
+After building:
+
+    cd build
+    make test
+
+Or run the test directly:
+
+    qore test/sysconf.qtest
+
+Documentation
+-------------
+
+Full API documentation is generated with Doxygen:
+
+    cd build
+    make docs
+
+License
+-------
+
+This module is released under the LGPL 2.1 license.
+See the COPYING file for the full license text.
+
+Repository
+----------
+
+https://github.com/qoretechnologies/module-sysconf

--- a/src/constants_pathconf.qpp
+++ b/src/constants_pathconf.qpp
@@ -112,67 +112,67 @@
 ///@{
 namespace Qore::Sysconf::Pathconf;
 
-//! Confstr wrapper for _PC_LINK_MAX
+//! Pathconf wrapper for _PC_LINK_MAX: maximum number of links to a file
 const PC_LINK_MAX = _PC_LINK_MAX;
 
-//! Confstr wrapper for _PC_MAX_CANON
+//! Pathconf wrapper for _PC_MAX_CANON: maximum length of a formatted input line
 const PC_MAX_CANON = _PC_MAX_CANON;
 
-//! Confstr wrapper for _PC_MAX_INPUT
+//! Pathconf wrapper for _PC_MAX_INPUT: maximum length of an input line
 const PC_MAX_INPUT = _PC_MAX_INPUT;
 
-//! Confstr wrapper for _PC_NAME_MAX
+//! Pathconf wrapper for _PC_NAME_MAX: maximum length of a filename
 const PC_NAME_MAX = _PC_NAME_MAX;
 
-//! Confstr wrapper for _PC_PATH_MAX
+//! Pathconf wrapper for _PC_PATH_MAX: maximum length of a pathname
 const PC_PATH_MAX = _PC_PATH_MAX;
 
-//! Confstr wrapper for _PC_PIPE_BUF
+//! Pathconf wrapper for _PC_PIPE_BUF: size of the pipe buffer
 const PC_PIPE_BUF = _PC_PIPE_BUF;
 
-//! Confstr wrapper for _PC_CHOWN_RESTRICTED
+//! Pathconf wrapper for _PC_CHOWN_RESTRICTED: chown restricted to root
 const PC_CHOWN_RESTRICTED = _PC_CHOWN_RESTRICTED;
 
-//! Confstr wrapper for _PC_NO_TRUNC
+//! Pathconf wrapper for _PC_NO_TRUNC: filenames are not truncated
 const PC_NO_TRUNC = _PC_NO_TRUNC;
 
-//! Confstr wrapper for _PC_VDISABLE
+//! Pathconf wrapper for _PC_VDISABLE: terminal special characters can be disabled
 const PC_VDISABLE = _PC_VDISABLE;
 
-//! Confstr wrapper for _PC_SYNC_IO
+//! Pathconf wrapper for _PC_SYNC_IO: synchronized I/O may be performed
 const PC_SYNC_IO = _PC_SYNC_IO;
 
-//! Confstr wrapper for _PC_ASYNC_IO
+//! Pathconf wrapper for _PC_ASYNC_IO: asynchronous I/O may be performed
 const PC_ASYNC_IO = _PC_ASYNC_IO;
 
-//! Confstr wrapper for _PC_PRIO_IO
+//! Pathconf wrapper for _PC_PRIO_IO: prioritized I/O may be performed
 const PC_PRIO_IO = _PC_PRIO_IO;
 
-//! Confstr wrapper for _PC_SOCK_MAXBUF
+//! Pathconf wrapper for _PC_SOCK_MAXBUF: maximum socket buffer size
 const PC_SOCK_MAXBUF = _PC_SOCK_MAXBUF;
 
-//! Confstr wrapper for _PC_FILESIZEBITS
+//! Pathconf wrapper for _PC_FILESIZEBITS: minimum bits needed to represent file size
 const PC_FILESIZEBITS = _PC_FILESIZEBITS;
 
-//! Confstr wrapper for _PC_REC_INCR_XFER_SIZE
+//! Pathconf wrapper for _PC_REC_INCR_XFER_SIZE: recommended increment for file transfer sizes
 const PC_REC_INCR_XFER_SIZE = _PC_REC_INCR_XFER_SIZE;
 
-//! Confstr wrapper for _PC_REC_MAX_XFER_SIZE
+//! Pathconf wrapper for _PC_REC_MAX_XFER_SIZE: recommended maximum file transfer size
 const PC_REC_MAX_XFER_SIZE = _PC_REC_MAX_XFER_SIZE;
 
-//! Confstr wrapper for _PC_REC_MIN_XFER_SIZE
+//! Pathconf wrapper for _PC_REC_MIN_XFER_SIZE: recommended minimum file transfer size
 const PC_REC_MIN_XFER_SIZE = _PC_REC_MIN_XFER_SIZE;
 
-//! Confstr wrapper for _PC_REC_XFER_ALIGN
+//! Pathconf wrapper for _PC_REC_XFER_ALIGN: recommended transfer buffer alignment
 const PC_REC_XFER_ALIGN = _PC_REC_XFER_ALIGN;
 
-//! Confstr wrapper for _PC_ALLOC_SIZE_MIN
+//! Pathconf wrapper for _PC_ALLOC_SIZE_MIN: minimum allocation size for a file
 const PC_ALLOC_SIZE_MIN = _PC_ALLOC_SIZE_MIN;
 
-//! Confstr wrapper for _PC_SYMLINK_MAX
+//! Pathconf wrapper for _PC_SYMLINK_MAX: maximum length of a symbolic link
 const PC_SYMLINK_MAX = _PC_SYMLINK_MAX;
 
-//! Confstr wrapper for _PC_2_SYMLINKS
+//! Pathconf wrapper for _PC_2_SYMLINKS: symbolic links are supported
 const PC_2_SYMLINKS = _PC_2_SYMLINKS;
 ///@}
 

--- a/src/constants_sysconf.qpp
+++ b/src/constants_sysconf.qpp
@@ -892,19 +892,25 @@
 ///@{
 namespace Qore::Sysconf::Sysconf;
 
-//! TODO/FIXME
+//! Returned when there is no defined limit for a configurable parameter
 const SC_NO_LIMIT = -1;
 
-//! Sysconf wrapper for _SC_CLK_TCK
+//! Sysconf wrapper for _SC_ARG_MAX: maximum length of arguments to exec functions
+const SC_ARG_MAX = _SC_ARG_MAX;
+
+//! Sysconf wrapper for _SC_CHILD_MAX: maximum number of simultaneous processes per user
+const SC_CHILD_MAX = _SC_CHILD_MAX;
+
+//! Sysconf wrapper for _SC_CLK_TCK: number of clock ticks per second
 const SC_CLK_TCK = _SC_CLK_TCK;
 
-//! Sysconf wrapper for _SC_NGROUPS_MAX
+//! Sysconf wrapper for _SC_NGROUPS_MAX: maximum number of supplementary groups per user
 const SC_NGROUPS_MAX = _SC_NGROUPS_MAX;
 
-//! Sysconf wrapper for _SC_OPEN_MAX
+//! Sysconf wrapper for _SC_OPEN_MAX: maximum number of open files per process
 const SC_OPEN_MAX = _SC_OPEN_MAX;
 
-//! Sysconf wrapper for _SC_STREAM_MAX
+//! Sysconf wrapper for _SC_STREAM_MAX: maximum number of streams per process
 const SC_STREAM_MAX = _SC_STREAM_MAX;
 
 //! Sysconf wrapper for _SC_TZNAME_MAX
@@ -979,10 +985,10 @@ const SC_MQ_PRIO_MAX = _SC_MQ_PRIO_MAX;
 //! Sysconf wrapper for _SC_VERSION
 const SC_VERSION = _SC_VERSION;
 
-//! Sysconf wrapper for _SC_PAGESIZE
+//! Sysconf wrapper for _SC_PAGESIZE: system page size in bytes
 const SC_PAGESIZE = _SC_PAGESIZE;
 
-//! Sysconf wrapper for _SC_PAGE_SIZE
+//! Sysconf wrapper for _SC_PAGE_SIZE: system page size in bytes (same as SC_PAGESIZE)
 const SC_PAGE_SIZE = _SC_PAGE_SIZE;
 
 //! Sysconf wrapper for _SC_RTSIG_MAX
@@ -1144,16 +1150,16 @@ const SC_THREAD_PRIO_PROTECT = _SC_THREAD_PRIO_PROTECT;
 //! Sysconf wrapper for _SC_THREAD_PROCESS_SHARED
 const SC_THREAD_PROCESS_SHARED = _SC_THREAD_PROCESS_SHARED;
 
-//! Sysconf wrapper for _SC_NPROCESSORS_CONF
+//! Sysconf wrapper for _SC_NPROCESSORS_CONF: number of processors configured
 const SC_NPROCESSORS_CONF = _SC_NPROCESSORS_CONF;
 
-//! Sysconf wrapper for _SC_NPROCESSORS_ONLN
+//! Sysconf wrapper for _SC_NPROCESSORS_ONLN: number of processors currently online
 const SC_NPROCESSORS_ONLN = _SC_NPROCESSORS_ONLN;
 
-//! Sysconf wrapper for _SC_PHYS_PAGES
+//! Sysconf wrapper for _SC_PHYS_PAGES: total number of physical memory pages
 const SC_PHYS_PAGES = _SC_PHYS_PAGES;
 
-//! Sysconf wrapper for _SC_AVPHYS_PAGES
+//! Sysconf wrapper for _SC_AVPHYS_PAGES: number of available physical memory pages
 const SC_AVPHYS_PAGES = _SC_AVPHYS_PAGES;
 
 //! Sysconf wrapper for _SC_ATEXIT_MAX

--- a/src/sysconf.qpp
+++ b/src/sysconf.qpp
@@ -38,7 +38,7 @@
 
     This module is released under the <a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html">LGPL 2.1</a>
     and is tagged as such in the module's header (meaning it can be loaded unconditionally regardless of how
-    the %Qore library was initialized). This version of the module requires Qore 0.8.0+ to compile and run.
+    the %Qore library was initialized). This version of the module requires Qore 1.12.4+ to compile and run.
 
     To use the module in a %Qore script, use the \c %%requires directive as follows:
     @code %requires sysconf @endcode
@@ -153,27 +153,28 @@ hash<string, int> sysconf_constants() [flags=CONSTANT] {
 
     @return A string with the requested value
 
-    @throw CONFSTR-ERRO
+    @throw CONFSTR-ERROR
  */
 string confstr(int param) [flags=RET_VALUE_ONLY] {
 #ifdef HAVE_CONFSTR
-    size_t len = confstr (param, NULL, 0);
-    if (!len || errno != 0)
-    {
+    errno = 0;
+    size_t len = confstr(param, NULL, 0);
+    if (!len || errno != 0) {
         xsink->raiseErrnoException("CONFSTR-ERROR", errno, "confstr(%d) failed", param);
         return 0;
     }
 
     SimpleRefHolder<QoreStringNode> rv(new QoreStringNode);
-    // this reserves len + 1 bytes in the string
+    // reserve len bytes (confstr returns size including null terminator)
     rv->reserve(len);
     // theoretically there should be no error here, but just in case we have additional error handling
     errno = 0;
-    if (!confstr(param, (char*)rv->getBuffer(), len + 1) || errno) {
+    if (!confstr(param, (char*)rv->getBuffer(), len) || errno) {
         xsink->raiseErrnoException("CONFSTR-ERROR", errno, "confstr(%d) failed", param);
         return 0;
     }
-    rv->terminate(len);
+    // len includes null terminator, so actual string length is len - 1
+    rv->terminate(len - 1);
     return rv.release();
 
 #else

--- a/test/sysconf.qtest
+++ b/test/sysconf.qtest
@@ -4,6 +4,7 @@
 %strict-args
 %require-types
 %enable-all-warnings
+%disable-warning return-value-ignored
 
 %requires sysconf
 
@@ -12,14 +13,148 @@
 %exec-class SysconfTest
 
 class SysconfTest inherits QUnit::Test {
-    constructor() : QUnit::Test("OracleTest", "1.0", \ARGV) {
-        addTestCase("basic test", \basicTest());
+    constructor() : QUnit::Test("SysconfTest", "1.0", \ARGV) {
+        addTestCase("sysconf basic test", \sysconfBasicTest());
+        addTestCase("sysconf multiple constants test", \sysconfMultipleConstantsTest());
+        addTestCase("sysconf error test", \sysconfErrorTest());
+        addTestCase("sysconf_constants helper test", \sysconfConstantsHelperTest());
+        addTestCase("confstr basic test", \confstrBasicTest());
+        addTestCase("confstr error test", \confstrErrorTest());
+        addTestCase("confstr_constants helper test", \confstrConstantsHelperTest());
+        addTestCase("pathconf basic test", \pathconfBasicTest());
+        addTestCase("pathconf multiple constants test", \pathconfMultipleConstantsTest());
+        addTestCase("pathconf error test", \pathconfErrorTest());
+        addTestCase("pathconf_constants helper test", \pathconfConstantsHelperTest());
         set_return_value(main());
     }
 
-    basicTest() {
-        assertGe(1, sysconf(Sysconf::SC_NPROCESSORS_ONLN));
-        assertEq(Type::String, confstr(CS_POSIX_V7_ILP32_OFF32_CFLAGS).type());
-        assertGt(0, pathconf(get_script_path(), PC_NAME_MAX));
+    # sysconf tests
+    sysconfBasicTest() {
+        # Test that we can get the number of online processors
+        int cpus = sysconf(Sysconf::SC_NPROCESSORS_ONLN);
+        assertGe(1, cpus, "should have at least 1 CPU online");
+
+        # Test page size is a reasonable value (typically 4096 or larger)
+        int pagesize = sysconf(Sysconf::SC_PAGESIZE);
+        assertGe(512, pagesize, "page size should be at least 512 bytes");
+        # Page size should be a power of 2
+        assertEq(0, pagesize & (pagesize - 1), "page size should be a power of 2");
+    }
+
+    sysconfMultipleConstantsTest() {
+        # Test various commonly used sysconf values
+        int arg_max = sysconf(Sysconf::SC_ARG_MAX);
+        assertTrue(arg_max >= -1, "SC_ARG_MAX should return valid value or -1 for no limit");
+
+        int open_max = sysconf(Sysconf::SC_OPEN_MAX);
+        assertTrue(open_max >= -1, "SC_OPEN_MAX should return valid value or -1 for no limit");
+
+        int child_max = sysconf(Sysconf::SC_CHILD_MAX);
+        assertTrue(child_max >= -1, "SC_CHILD_MAX should return valid value or -1 for no limit");
+
+        int nprocessors_conf = sysconf(Sysconf::SC_NPROCESSORS_CONF);
+        assertGe(1, nprocessors_conf, "should have at least 1 CPU configured");
+
+        # Number of online processors should not exceed configured processors
+        int nprocessors_onln = sysconf(Sysconf::SC_NPROCESSORS_ONLN);
+        assertLe(nprocessors_onln, nprocessors_conf, "online CPUs should not exceed configured CPUs");
+
+        # Test physical memory pages
+        int phys_pages = sysconf(Sysconf::SC_PHYS_PAGES);
+        assertGt(0, phys_pages, "should have physical memory pages");
+    }
+
+    sysconfErrorTest() {
+        # Test with invalid parameter - should throw SYSCONF-ERROR
+        assertThrows("SYSCONF-ERROR", sub() { sysconf(-99999); });
+    }
+
+    sysconfConstantsHelperTest() {
+        hash consts = sysconf_constants();
+
+        # Verify the hash is not empty
+        assertGt(0, consts.size(), "sysconf_constants should return non-empty hash");
+
+        # Verify some expected constants exist
+        assertTrue(consts.hasKey("SC_NPROCESSORS_ONLN"), "should have SC_NPROCESSORS_ONLN constant");
+        assertTrue(consts.hasKey("SC_PAGESIZE"), "should have SC_PAGESIZE constant");
+        assertTrue(consts.hasKey("SC_ARG_MAX"), "should have SC_ARG_MAX constant");
+        assertTrue(consts.hasKey("SC_OPEN_MAX"), "should have SC_OPEN_MAX constant");
+    }
+
+    # confstr tests
+    confstrBasicTest() {
+        # Test getting the default path
+        string path = confstr(Confstr::CS_PATH);
+        assertEq(Type::String, path.type(), "confstr should return a string");
+        # Path should contain typical bin directories
+        assertTrue(path.size() >= 0, "CS_PATH should return a string (may be empty on some systems)");
+    }
+
+    confstrErrorTest() {
+        # Test with invalid parameter - should throw CONFSTR-ERROR
+        assertThrows("CONFSTR-ERROR", sub() { confstr(-99999); });
+    }
+
+    confstrConstantsHelperTest() {
+        hash consts = confstr_constants();
+
+        # Verify the hash is not empty
+        assertGt(0, consts.size(), "confstr_constants should return non-empty hash");
+
+        # Verify some expected constants exist
+        assertTrue(consts.hasKey("CS_PATH"), "should have CS_PATH constant");
+    }
+
+    # pathconf tests
+    pathconfBasicTest() {
+        string test_path = get_script_path();
+
+        # Test getting maximum filename length
+        int name_max = pathconf(test_path, Pathconf::PC_NAME_MAX);
+        assertGt(0, name_max, "PC_NAME_MAX should be positive for valid path");
+
+        # Test getting maximum path length
+        int path_max = pathconf(test_path, Pathconf::PC_PATH_MAX);
+        assertTrue(path_max >= -1, "PC_PATH_MAX should return valid value or -1");
+    }
+
+    pathconfMultipleConstantsTest() {
+        string test_path = get_script_path();
+
+        # Test various pathconf values
+        int link_max = pathconf(test_path, Pathconf::PC_LINK_MAX);
+        assertTrue(link_max >= -1, "PC_LINK_MAX should return valid value or -1");
+
+        int pipe_buf = pathconf(test_path, Pathconf::PC_PIPE_BUF);
+        assertTrue(pipe_buf >= -1, "PC_PIPE_BUF should return valid value or -1");
+
+        int filesizebits = pathconf(test_path, Pathconf::PC_FILESIZEBITS);
+        assertTrue(filesizebits >= -1, "PC_FILESIZEBITS should return valid value or -1");
+
+        # Test with current directory
+        int name_max_cwd = pathconf(".", Pathconf::PC_NAME_MAX);
+        assertGt(0, name_max_cwd, "PC_NAME_MAX should be positive for current directory");
+    }
+
+    pathconfErrorTest() {
+        # Test with non-existent file - should throw PATHCONF-ERROR
+        assertThrows("PATHCONF-ERROR", sub() { pathconf("/nonexistent/path/that/does/not/exist", Pathconf::PC_NAME_MAX); });
+
+        # Test with invalid parameter on valid path
+        assertThrows("PATHCONF-ERROR", sub() { pathconf(get_script_path(), -99999); });
+    }
+
+    pathconfConstantsHelperTest() {
+        hash consts = pathconf_constants();
+
+        # Verify the hash is not empty
+        assertGt(0, consts.size(), "pathconf_constants should return non-empty hash");
+
+        # Verify some expected constants exist
+        assertTrue(consts.hasKey("PC_NAME_MAX"), "should have PC_NAME_MAX constant");
+        assertTrue(consts.hasKey("PC_PATH_MAX"), "should have PC_PATH_MAX constant");
+        assertTrue(consts.hasKey("PC_LINK_MAX"), "should have PC_LINK_MAX constant");
+        assertTrue(consts.hasKey("PC_PIPE_BUF"), "should have PC_PIPE_BUF constant");
     }
 }


### PR DESCRIPTION
## Summary

- Fixed buffer overflow in `confstr()` function
- Fixed errno initialization before first `confstr()` call  
- Fixed documentation typos and errors
- Added missing constants (`SC_ARG_MAX`, `SC_CHILD_MAX`)
- Expanded test coverage from 3 to 33 assertions
- Updated GitLab CI configuration

## Bug Fixes

- **Buffer overflow in `confstr()`**: Changed `len + 1` to `len` and `terminate(len)` to `terminate(len - 1)` since `confstr()` returns size including null terminator
- **Missing errno initialization**: Added `errno = 0` before first `confstr()` call to prevent false-positive errors from stale errno values
- **Documentation typo**: Fixed `CONFSTR-ERRO` → `CONFSTR-ERROR`
- **Pathconf documentation**: Fixed all "Confstr wrapper" → "Pathconf wrapper"

## Test plan

- [x] All 11 test cases pass with 33 assertions
- [x] Negative tests verify error handling for invalid parameters
- [x] Helper function tests verify constant availability

refs qoretechnologies/qore#5100

🤖 Generated with [Claude Code](https://claude.com/claude-code)